### PR TITLE
Evaluate the emotion input

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -33,6 +33,8 @@ fn main() {
         #[cfg(feature = "visuals")]
         let visuals = visuals.clone();
         move || {
+            let start = std::time::Instant::now();
+
             loop {
                 #[cfg(feature = "fieldbus")]
                 if let Some(fieldbus) = &mut fieldbus {
@@ -79,6 +81,11 @@ fn main() {
 
                 #[cfg(feature = "visuals")]
                 visuals.update_channels(&logic.outputs().channels);
+
+                // TODO: Dummy emotion setting
+                if (std::time::Instant::now() - start).as_secs() > 5 {
+                    logic.inputs_mut().emotion = Some(logic::Emotion::Surprised);
+                }
 
                 logic.run(std::time::Instant::now());
 


### PR DESCRIPTION
Set crab face to the emotion input.  Reset after no change of emotion for 60 seconds.

Add some demo-code to showcase how emotions can be set in `main.rs`.  @git-commit, you can replace this with an input from the HTTP API when you get around to it.